### PR TITLE
Feature/add empty postal code value

### DIFF
--- a/src/components/Forms/UserForm/UserForm.tsx
+++ b/src/components/Forms/UserForm/UserForm.tsx
@@ -125,13 +125,18 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
   const isForFun = watch('is_filled_for_fun');
 
   /**
-   * In case postal code value is empty string, replace with null value for API compatibility.
+   * In case 1 or both postal code values are empty string, replace with null value for API compatibility.
    * @param data
    * @returns data
    */
   const formatPostalCodes = (data: UserFormTypes) => {
-    if (data.postal_code === '') {
-      data.postal_code = null;
+    if (data.postal_code === '' || data.optional_postal_code === '') {
+      if (data.postal_code === '') {
+        data.postal_code = null;
+      }
+      if (data.optional_postal_code === '') {
+        data.optional_postal_code = null;
+      }
       return data;
     } else {
       return data;

--- a/src/components/Forms/UserForm/UserForm.tsx
+++ b/src/components/Forms/UserForm/UserForm.tsx
@@ -38,15 +38,31 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
   const renderOptions = () => {
     const sortedPostalCodes = sortPostalCodes(postalCodeData);
 
-    return sortedPostalCodes?.map((item) => (
+    const options = [];
+
+    options.push(
       <option
-        key={item?.id}
-        value={item?.name?.fi}
-        aria-label={`${intl.formatMessage({ id: 'app.form.helperText.postCode' })} ${item.name.fi}`}
-      >
-        {item?.name?.fi}
-      </option>
-    ));
+        key="empty"
+        value=""
+        aria-label={intl.formatMessage({ id: 'app.form.empty.value' })}
+      />,
+    );
+
+    sortedPostalCodes.forEach((item) => {
+      options.push(
+        <option
+          key={item?.id}
+          value={item?.name?.fi}
+          aria-label={`${intl.formatMessage({ id: 'app.form.helperText.postCode' })} ${
+            item?.name?.fi
+          }`}
+        >
+          {item?.name?.fi}
+        </option>,
+      );
+    });
+
+    return options;
   };
 
   const currentYear = new Date().getFullYear();
@@ -108,10 +124,14 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
   const isInterestedInMobility = watch('is_interested_in_mobility');
   const isForFun = watch('is_filled_for_fun');
 
-  const removePostalCodes = (data: UserFormTypes) => {
-    if (serviceMapApiError) {
-      delete data.postal_code;
-      delete data.optional_postal_code;
+  /**
+   * In case postal code value is empty string, replace with null value for API compatibility.
+   * @param data
+   * @returns data
+   */
+  const formatPostalCodes = (data: UserFormTypes) => {
+    if (data.postal_code === '') {
+      data.postal_code = null;
       return data;
     } else {
       return data;
@@ -120,7 +140,7 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
 
   const onSubmit: SubmitHandler<UserFormTypes> = (data) => {
     if (userId?.length) {
-      postUserInfo(removePostalCodes(data), userId, setAnswerStatus, setIsApiError, token);
+      postUserInfo(formatPostalCodes(data), userId, setAnswerStatus, setIsApiError, token);
     }
   };
 
@@ -191,9 +211,9 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
                   </div>
                   <div>
                     <select
-                      {...register('postal_code', { required: !serviceMapApiError ? true : false })}
+                      {...register('postal_code', { required: false })}
                       role="listbox"
-                      aria-required={!serviceMapApiError ? 'true' : 'false'}
+                      aria-required="false"
                       aria-invalid={errors.postal_code ? true : false}
                       className="select-field"
                     >
@@ -201,7 +221,7 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
                     </select>
                   </div>
                   <div className="mb-1">
-                    <small>{intl.formatMessage({ id: 'app.form.mandatory.field' })}</small>
+                    <small>{intl.formatMessage({ id: 'app.form.postalCode.field' })}</small>
                   </div>
                   {errors.postal_code && (
                     <div className="mb-2">

--- a/src/components/Forms/UserForm/UserForm.tsx
+++ b/src/components/Forms/UserForm/UserForm.tsx
@@ -130,17 +130,14 @@ const UserForm = ({ answerStatus, setAnswerStatus }: UserFormProps) => {
    * @returns data
    */
   const formatPostalCodes = (data: UserFormTypes) => {
-    if (data.postal_code === '' || data.optional_postal_code === '') {
-      if (data.postal_code === '') {
-        data.postal_code = null;
-      }
-      if (data.optional_postal_code === '') {
-        data.optional_postal_code = null;
-      }
-      return data;
-    } else {
-      return data;
+    const updatedData = { ...data };
+    if (updatedData.postal_code === '') {
+      updatedData.postal_code = null;
     }
+    if (updatedData.optional_postal_code === '') {
+      updatedData.optional_postal_code = null;
+    }
+    return updatedData;
   };
 
   const onSubmit: SubmitHandler<UserFormTypes> = (data) => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,6 +31,7 @@
   "app.form.helperText.year": "Year",
   "app.form.helperText.postCode": "Post code",
   "app.form.helperText.characters": "characters",
+  "app.form.empty.value": "Empty",
   "app.general.language.fi": "Suomeksi",
   "app.general.language.en": "In English",
   "app.general.language.sv": "På svenska",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,6 +22,7 @@
   "app.form.gender.male": "Male",
   "app.form.gender.female": "Female",
   "app.form.gender.other": "Other",
+  "app.form.postalCode.field": "In case you don't live in Turku, you can skip this question",
   "app.form.mandatory.field": "Mandatory field",
   "app.form.optional.field": "In case you don't work or study, you can skip this question",
   "app.form.email.invalid": "Enter valid email address",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -31,6 +31,7 @@
   "app.form.helperText.year": "Vuosi",
   "app.form.helperText.postCode": "Postinumero",
   "app.form.helperText.characters": "merkkiä",
+  "app.form.empty.value": "Tyhjä",
   "app.general.language.fi": "Suomeksi",
   "app.general.language.en": "In English",
   "app.general.language.sv": "På svenska",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -22,6 +22,7 @@
   "app.form.gender.male": "Mies",
   "app.form.gender.female": "Nainen",
   "app.form.gender.other": "Muu",
+  "app.form.postalCode.field": "Ohita kysymys, jos asut Turun ulkopuolella",
   "app.form.mandatory.field": "Pakollinen kenttä",
   "app.form.optional.field": "Ohita kysymys, jos et opiskele tai käy töissä",
   "app.form.email.invalid": "Kirjoita kelvollinen sähköpostiosoite",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -31,6 +31,7 @@
   "app.form.helperText.year": "År",
   "app.form.helperText.postCode": "Postnummer",
   "app.form.helperText.characters": "tecken",
+  "app.form.empty.value": "Tömma",
   "app.general.language.fi": "Suomeksi",
   "app.general.language.en": "In English",
   "app.general.language.sv": "På svenska",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -22,6 +22,7 @@
   "app.form.gender.male": "Man",
   "app.form.gender.female": "Kvinna",
   "app.form.gender.other": "Övrig",
+  "app.form.postalCode.field": "Hoppa över frågan om du bor utanför Åbo",
   "app.form.mandatory.field": "Obligatoriskt fält",
   "app.form.optional.field": "Hoppa över frågan om du inte studerar eller arbetar",
   "app.form.email.invalid": "Skriv in en giltig e-postadress",


### PR DESCRIPTION
# Add empty default value for postal codes

## Description
Add empty (default) value for select list that renders postal codes. Update required value. Check if postal code values are empty string and replace them with null value for API compatibility. For example, the user who lives outside of Turku, can now skip the selection.

#### Trello card 91
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Add empty default value
  1. src/components/Forms/UserForm/UserForm.tsx
     * Add `empty default value` for select list that renders postal codes (can't be `null`, so has to be `''`). Update `required value` into `false`. Check if postal code values are `empty strings` and replace them with `null value` for API compatibility.
  
#### Update translations
  1. src/i18n/en.json, src/i18n/fi.json & src/i18n/sv.json
     * Update translations
