### PR TITLE
Feature/prevent next without answer

### DIFF
--- a/src/components/QuestionForm/QuestionForm.tsx
+++ b/src/components/QuestionForm/QuestionForm.tsx
@@ -46,6 +46,7 @@ const QuestionForm = () => {
     question3Answer,
     question7Answer,
     otherValue,
+    allowNext,
     questionApiError,
   } = useAppSelector((state) => state.question);
   const { localeSelection } = useAppSelector((state) => state.settings);
@@ -412,7 +413,12 @@ const QuestionForm = () => {
         </div>
         <div className="buttons-container-flex">
           {!isLastPage && (
-            <Button className="button-primary" role="button" onClick={() => handleNext()}>
+            <Button
+              className="button-primary"
+              role="button"
+              disabled={!allowNext}
+              onClick={() => handleNext()}
+            >
               <p className="text-normal">{intl.formatMessage({ id: 'app.buttons.next' })}</p>
             </Button>
           )}

--- a/src/components/Tables/TableCommon/TableCommon.tsx
+++ b/src/components/Tables/TableCommon/TableCommon.tsx
@@ -26,6 +26,8 @@ const TableCommon: React.FC<TableCommonProps> = ({ question }) => {
     setQuestion7Answer,
     setOtherValue,
     resetOtherValue,
+    setAllowNext,
+    resetAllowNext,
   } = bindActionCreators(questionSlice.actions, dispatch);
 
   const { otherValue } = useAppSelector((state) => state.question);
@@ -43,11 +45,23 @@ const TableCommon: React.FC<TableCommonProps> = ({ question }) => {
   }, []);
 
   useEffect(() => {
+    resetAllowNext();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     setOtherCount(otherValue.length);
   }, [otherValue]);
 
   useEffect(() => {
     setQuestionAnswer(mainOptions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mainOptions]);
+
+  useEffect(() => {
+    if (mainOptions.length) {
+      setAllowNext(true);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mainOptions]);
 

--- a/src/components/Tables/TableExtended/TableExtended.tsx
+++ b/src/components/Tables/TableExtended/TableExtended.tsx
@@ -64,9 +64,9 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
   };
 
   useEffect(() => {
-    const maxCount = questionData?.sub_questions?.length;
+    const maxLength = questionData?.sub_questions?.length;
     const subOptionValues = getSubOptionValues();
-    if (questionData.number === '1' && subOptionValues?.length === maxCount) {
+    if (questionData.number === '1' && subOptionValues?.length === maxLength) {
       setAllowNext(true);
     }
     if (questionData.number !== '1' && subOptionValues?.length) {

--- a/src/components/Tables/TableExtended/TableExtended.tsx
+++ b/src/components/Tables/TableExtended/TableExtended.tsx
@@ -20,10 +20,14 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
   const intl = useIntl();
 
   const dispatch = useAppDispatch();
-  const { setSubQuestionAnswer, setCarCount, setOtherValue, resetOtherValue } = bindActionCreators(
-    questionSlice.actions,
-    dispatch,
-  );
+  const {
+    setSubQuestionAnswer,
+    setCarCount,
+    setOtherValue,
+    resetOtherValue,
+    setAllowNext,
+    resetAllowNext,
+  } = bindActionCreators(questionSlice.actions, dispatch);
 
   const { question3Answer, otherValue } = useAppSelector((state) => state.question);
 
@@ -37,8 +41,20 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
   }, []);
 
   useEffect(() => {
+    resetAllowNext();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     setOtherCount(otherValue.length);
   }, [otherValue]);
+
+  useEffect(() => {
+    if (subOptions.length) {
+      setAllowNext(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [subOptions]);
 
   const getTransportType = (str: string) => {
     const lower = str.toLowerCase();

--- a/src/components/Tables/TableExtended/TableExtended.tsx
+++ b/src/components/Tables/TableExtended/TableExtended.tsx
@@ -49,8 +49,26 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
     setOtherCount(otherValue.length);
   }, [otherValue]);
 
+  /**
+   * Count number of unique sub option values
+   * @returns array
+   */
+  const getSubOptionValues = () => {
+    const subOptionNumbers: (string | number | undefined)[] = [];
+    subOptions.forEach((item) => {
+      if (!subOptionNumbers.includes(item.sub_question)) {
+        subOptionNumbers.push(item.sub_question);
+      }
+    });
+    return subOptionNumbers;
+  };
+
   useEffect(() => {
-    if (subOptions.length) {
+    const subOptionValues = getSubOptionValues();
+    if (questionData.number === '1' && subOptionValues?.length === 8) {
+      setAllowNext(true);
+    }
+    if (questionData.number !== '1' && subOptionValues?.length) {
       setAllowNext(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Tables/TableExtended/TableExtended.tsx
+++ b/src/components/Tables/TableExtended/TableExtended.tsx
@@ -64,8 +64,9 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
   };
 
   useEffect(() => {
+    const maxCount = questionData?.sub_questions?.length;
     const subOptionValues = getSubOptionValues();
-    if (questionData.number === '1' && subOptionValues?.length === 8) {
+    if (questionData.number === '1' && subOptionValues?.length === maxCount) {
       setAllowNext(true);
     }
     if (questionData.number !== '1' && subOptionValues?.length) {

--- a/src/redux/slices/questionSlice.ts
+++ b/src/redux/slices/questionSlice.ts
@@ -53,6 +53,7 @@ export const initialState = {
   },
   question7Answer: '',
   otherValue: '',
+  allowNext: false,
   questionApiError: false,
 };
 
@@ -90,6 +91,12 @@ export const questionSlice = createSlice({
     resetOtherValue: (state) => {
       state.otherValue = '';
     },
+    setAllowNext: (state, action) => {
+      state.allowNext = action.payload;
+    },
+    resetAllowNext: (state) => {
+      state.allowNext = false;
+    },
     setQuestionApiError: (state, action) => {
       state.questionApiError = action.payload;
     },
@@ -107,6 +114,8 @@ export const {
   setQuestion7Answer,
   setOtherValue,
   resetOtherValue,
+  setAllowNext,
+  resetAllowNext,
   setQuestionApiError,
 } = questionSlice.actions;
 

--- a/src/utils/mobilityProfileAPI.ts
+++ b/src/utils/mobilityProfileAPI.ts
@@ -39,50 +39,6 @@ const fetchQuestionsWithConditions = async (
   }
 };
 
-const fetchOneQuestion = async (
-  questionId: number,
-  setData: React.Dispatch<React.SetStateAction<Question>>,
-) => {
-  try {
-    const response = await fetch(`${apiUrl}/question/${questionId}/`);
-    const jsonData = await response.json();
-    setData(jsonData);
-  } catch (error) {
-    let message;
-    if (error instanceof Error) message = error.message;
-    else message = String(error);
-    console.warn(message);
-  }
-};
-
-const fetchQuestionStates = async (token: string) => {
-  const headers = new Headers({
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    Authorization: `Token ${token}`,
-  });
-
-  const requestOptions: RequestInit = {
-    headers: headers,
-    credentials: 'include',
-  };
-
-  try {
-    const response = await fetch(
-      `${apiUrl}/question/get_questions_conditions_states/`,
-      requestOptions,
-    );
-    const jsonData = await response.json();
-    const values = jsonData;
-    return values;
-  } catch (error) {
-    let message;
-    if (error instanceof Error) message = error.message;
-    else message = String(error);
-    console.warn(message);
-  }
-};
-
 const fetchUserResult = async (
   token: string,
   setData: React.Dispatch<React.SetStateAction<Result>>,
@@ -212,40 +168,6 @@ const fetchQuestionConditionMet = async (questionId: number, token: string) => {
     const jsonData = await response.json();
     const conditionValue = jsonData;
     return conditionValue;
-  } catch (error) {
-    let message;
-    if (error instanceof Error) message = error.message;
-    else message = String(error);
-    console.warn(message);
-  }
-};
-
-const fetchSubQuestionConditionMet = async (subQuestionId: number, token: string) => {
-  const headers = new Headers({
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    Authorization: `Token ${token}`,
-  });
-  const bodyObj = {
-    sub_question: subQuestionId,
-  };
-  const requestOptions: RequestInit = {
-    method: 'POST',
-    headers: headers,
-    credentials: 'include',
-    body: JSON.stringify(bodyObj),
-  };
-
-  try {
-    const response = await fetch(
-      `${apiUrl}/question/check_if_sub_question_condition_met/`,
-      requestOptions,
-    );
-    const jsonData = await response.json();
-    const conditionValue = jsonData;
-    if (conditionValue?.condition_met) {
-      return true;
-    } else return false;
   } catch (error) {
     let message;
     if (error instanceof Error) message = error.message;
@@ -406,14 +328,11 @@ const fetchPostalCodes = async (
 export {
   fetchQuestions,
   fetchQuestionsWithConditions,
-  fetchOneQuestion,
-  fetchQuestionStates,
   fetchUserResult,
   startPoll,
   logoutUser,
   hasQuestionCondition,
   fetchQuestionConditionMet,
-  fetchSubQuestionConditionMet,
   postQuestionAnswer,
   postUserInfo,
   postSubscribeInfo,


### PR DESCRIPTION
# Prevent navigating to next question before answering

## Description
Add new state (boolean) value that prevents navigation before user has answered the current question. This will avoid incorrect result calculation that might occur if the user skips questions.

### Trello card 93
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Prevent navigation before answer
 1. src/redux/slices/questionSlice.ts
     * Add a new `boolean variable` to the global state.
  
2. src/components/QuestionForm/QuestionForm.tsx
     * Use a new variable to manage `disabled state` of the `button`.
 
3. src/components/Tables/TableCommon/TableCommon.tsx
     * First reset the `allowNext` value and then update it when user has selected an option.
 
4. src/components/Tables/TableExtended/TableExtended.tsx
     * First reset the `allowNext` value and then update it when user has selected an option. For the first question wait until all `mobility options` have been selected (car, bus, bicycle etc.) and check the length against number of options.  Options with `0` `value` will work when calculating the result but `null` or `non-existing` values (eq. skipping options) do not.

#### Remove unused requests
  1. src/utils/mobilityProfileAPI.ts
     * Remove unused `HTTP -requests`.
