### PR TITLE
Reset allowNext properly

### DIFF
--- a/src/components/Tables/TableCommon/TableCommon.tsx
+++ b/src/components/Tables/TableCommon/TableCommon.tsx
@@ -45,9 +45,11 @@ const TableCommon: React.FC<TableCommonProps> = ({ question }) => {
   }, []);
 
   useEffect(() => {
-    resetAllowNext();
+    if (!mainOptions.length) {
+      resetAllowNext();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [mainOptions]);
 
   useEffect(() => {
     setOtherCount(otherValue.length);


### PR DESCRIPTION
# Fix to allow next state

## Description
Update `useEffect` that resets `allowNext` value to run every time `mainOptions` array is empty. This will update state properly if user removes all selections.

### Trello card 97
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Category subject
  1. src/components/Tables/TableCommon/TableCommon.tsx
     * Reset `allowNext` when `mainOptions` is empty and update `useEffect` dependency array. This will will update state and disable `button` if user removes all `checkbox` selections (thus making the array empty).
