### PR TITLE
Fix/improve responsive styles

### DIFF
--- a/src/components/Tables/TableCommon/TableCommon.tsx
+++ b/src/components/Tables/TableCommon/TableCommon.tsx
@@ -180,7 +180,7 @@ const TableCommon: React.FC<TableCommonProps> = ({ question }) => {
                 </td>
               ) : (
                 <td>
-                  <label htmlFor={`option_${option.id}`}>
+                  <label className="text-label" htmlFor={`option_${option.id}`}>
                     {renderLocaleValue(
                       getLocaleText,
                       option.value_fi,

--- a/src/components/Tables/TableExtended/TableExtended.tsx
+++ b/src/components/Tables/TableExtended/TableExtended.tsx
@@ -145,10 +145,6 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
     }
   };
 
-  const commonCellStyle = {
-    fontSize: '0.9rem',
-  };
-
   /**
    * Medium sized table with only few options that are rendered horizontally.
    * Suitable for question 1.
@@ -158,10 +154,16 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
     <>
       <thead>
         <tr>
-          <th style={commonCellStyle}>{intl.formatMessage({ id: 'app.text.options' })}</th>
+          <th>
+            <p className="text-normal-secondary">
+              {intl.formatMessage({ id: 'app.text.options' })}
+            </p>
+          </th>
           {optionsArray?.map((item) => (
-            <th key={item.value_fi} style={commonCellStyle}>
-              <p>{renderLocaleValue(getLocaleText, item.value_fi, item.value_en, item.value_sv)}</p>
+            <th key={item.value_fi}>
+              <p className="text-normal-secondary">
+                {renderLocaleValue(getLocaleText, item.value_fi, item.value_en, item.value_sv)}
+              </p>
             </th>
           ))}
         </tr>
@@ -169,8 +171,8 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
       <tbody>
         {subQuestionsArray?.map((item) => (
           <tr key={item.id}>
-            <td style={commonCellStyle}>
-              <label htmlFor={`row-${item.id}`}>
+            <td>
+              <label className="text-label-secondary" htmlFor={`row-${item.id}`}>
                 {renderLocaleValue(
                   getLocaleText,
                   item.description_fi,
@@ -245,7 +247,7 @@ const TableExtended: React.FC<TableExtendedProps> = ({ questionData }) => {
                   </td>
                 ) : (
                   <td>
-                    <label htmlFor={`row-${item.id}`}>
+                    <label className="text-label" htmlFor={`row-${item.id}`}>
                       {renderLocaleValue(
                         getLocaleText,
                         option.value_fi,

--- a/src/components/Tables/TableExtended/__tests__/TableExtended.test.tsx
+++ b/src/components/Tables/TableExtended/__tests__/TableExtended.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import finnishTranslations from '../../../../i18n/fi.json';
 import { renderWithProviders } from '../../../../testUtils/testUtils';
 import TableExtended from '../TableExtended';
 
@@ -61,7 +62,8 @@ describe('<TableExtended />', () => {
 
     const p = container.querySelectorAll('p');
     const label = container.querySelectorAll('label');
-    expect(p[0].textContent).toContain(mockProps.questionData.options[0].value_fi);
+    expect(p[0].textContent).toContain(finnishTranslations['app.text.options']);
+    expect(p[1].textContent).toContain(mockProps.questionData.options[0].value_fi);
     expect(label[0].textContent).toContain(mockProps.questionData.sub_questions[0].description_fi);
   });
 

--- a/src/components/TopBar/components/LocaleSelection/LocaleSelection.tsx
+++ b/src/components/TopBar/components/LocaleSelection/LocaleSelection.tsx
@@ -35,7 +35,7 @@ const LocaleSelection: React.FC = () => {
           >
             <p
               className={`mb-1 pl-2 ${
-                currentLocale === localeSelection ? 'header-h6' : 'text-normal'
+                currentLocale === localeSelection ? 'text-normal-bold' : 'text-normal'
               }`}
               style={{ color: currentLocale === localeSelection ? '#fff' : '#DEDEF1' }}
             >

--- a/src/style.scss
+++ b/src/style.scss
@@ -234,4 +234,8 @@ body {
   .container-sm {
     width: 100%;
   }
+
+  .text-container {
+    margin: 0 0.3rem;
+  }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -234,8 +234,4 @@ body {
   .container-sm {
     width: 100%;
   }
-
-  .text-container {
-    margin: 0 0.3rem;
-  }
 }

--- a/src/styles/base/_breakpoints.scss
+++ b/src/styles/base/_breakpoints.scss
@@ -1,3 +1,4 @@
+$screen-xxs-max: 400px;
 $screen-xs-max: 576px;
 $screen-sm-max: 768px;
 $screen-md-max: 992px;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -17,6 +17,12 @@
   line-height: 1.2rem;
 }
 
+.text-normal-secondary {
+  @extend .text-root;
+  font-size: 1rem;
+  line-height: 1.2rem;
+}
+
 .text-normal-bold {
   @extend .text-root;
   font-size: 1rem;
@@ -25,6 +31,12 @@
 }
 
 .text-label {
+  @extend .text-root;
+  font-size: 0.95rem;
+  line-height: 1.2rem;
+}
+
+.text-label-secondary {
   @extend .text-root;
   font-size: 0.95rem;
   line-height: 1.2rem;
@@ -80,14 +92,22 @@
 }
 
 @media (max-width: $screen-sm-max) {
+  .text-normal {
+    line-height: 1.1rem;
+  }
+
+  .text-normal-bold {
+    line-height: 1.1rem;
+  }
+
   .text-subtitle {
     font-size: 1.1rem;
     line-height: 1.2rem;
   }
 
   .header-h1 {
-    font-size: 1.5rem;
-    line-height: 1.6rem;
+    font-size: 1.4rem;
+    line-height: 1.5rem;
   }
 
   .header-h2 {
@@ -106,12 +126,66 @@
   }
 
   .header-h5 {
-    font-size: 1.05rem;
-    line-height: 1.15rem;
+    font-size: 1.1rem;
+    line-height: 1.2rem;
   }
 
   .header-h6 {
     font-size: 1rem;
     line-height: 1.1rem;
+  }
+}
+
+@media (max-width: $screen-xs-max) {
+  .text-normal-secondary {
+    font-size: 0.75rem;
+    line-height: 0.85rem;
+  }
+
+  .text-label-secondary {
+    font-size: 0.75rem;
+    line-height: 0.85rem;
+  }
+
+  .header-h1 {
+    font-size: 1.3rem;
+    line-height: 1.4rem;
+  }
+
+  .header-h2 {
+    font-size: 1.2rem;
+    line-height: 1.3rem;
+  }
+
+  .header-h3 {
+    font-size: 1.1rem;
+    line-height: 1.2rem;
+  }
+
+  .header-h4 {
+    font-size: 1rem;
+    line-height: 1.1rem;
+  }
+
+  .header-h5 {
+    font-size: 0.95rem;
+    line-height: 1.05rem;
+  }
+
+  .header-h6 {
+    font-size: 0.9rem;
+    line-height: 1rem;
+  }
+}
+
+@media (max-width: $screen-xxs-max) {
+  .text-normal-secondary {
+    font-size: 0.65rem;
+    line-height: 0.7rem;
+  }
+
+  .text-label-secondary {
+    font-size: 0.65rem;
+    line-height: 0.7rem;
   }
 }


### PR DESCRIPTION
# Improve styles for mobile screens
## Description
Adjust styles and fonts for smaller screens (especially for question 1 that didn't properly fit into mobile screens).

### Trello card 117

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update styles
1. src/styles/base/_typography.scss
     * Add new `fonts` and add new `font sizes`.
  
2. src/styles/base/_breakpoints.scss
     * Add new `breakpoint`.  
 
#### Update components
1. src/components/Tables/TableExtended/TableExtended.tsx
     * Add `paragraphs`, use `classes` for texts and remove unneeded `style variable`.
  
2. src/components/Tables/TableCommon/TableCommon.tsx
     * Add `paragraphs`, use `classes` for texts.

3. src/components/TopBar/components/LocaleSelection/LocaleSelection.tsx
     * Change class from `h6` to `bold` text.
  
4. src/components/Tables/TableExtended/__tests__/TableExtended.test.tsx
     * Update tests.